### PR TITLE
Add new feature to joeml language

### DIFF
--- a/lambda_example.jml
+++ b/lambda_example.jml
@@ -1,0 +1,3 @@
+apply f x { f x }
+
+main { printLn (apply (\n -> n + 1) 5) }

--- a/record_example.jml
+++ b/record_example.jml
@@ -1,0 +1,9 @@
+createPerson name age { { name = name, age = age } }
+
+main {
+  let
+    alice { createPerson "Alice" 30 }
+  in {
+    printLn alice.name
+  }
+}

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -62,11 +62,12 @@ function makeLetExpression(ctx: Ctx, let_expr: T.LetExpression): string {
 
 function makeFunctionCall(ctx: Ctx, fn: T.Application): string {
    // Check if this call is a tail call by looking at all tail calls in the function
-   const tail_calls = tailCalls(ctx.fn.name.value, ctx.fn.body)
+   // If ctx.fn is null (e.g., inside a lambda), there are no tail calls to optimize
+   const tail_calls = ctx.fn ? tailCalls(ctx.fn.name.value, ctx.fn.body) : []
    const isTailCall = tail_calls.some(tc => tc === fn)
-   
-   if (ctx.fn.name.value === fn.name.value && 
-       ctx.fn.parameters.length === fn.parameters.length && 
+
+   if (ctx.fn && ctx.fn.name.value === fn.name.value &&
+       ctx.fn.parameters.length === fn.parameters.length &&
        isTailCall) {
       const params = _.zipWith(
          ctx.fn.parameters,
@@ -83,7 +84,7 @@ function makeFunctionCall(ctx: Ctx, fn: T.Application): string {
       `
    } else {
       // Check if this is a parameter reference (not a function call)
-      if (fn.parameters.length === 0 && ctx.fn && ctx.fn.parameters.some(p => p.value === fn.name.value)) {
+      if (fn.parameters.length === 0 && ctx.fn && ctx.fn.parameters && ctx.fn.parameters.some(p => p.value === fn.name.value)) {
          // This is a parameter reference, not a function call
          return `${ctx.expect_return ? 'return' : ''} ${fn.name.value}`
       }
@@ -116,6 +117,30 @@ export function makeIfExpression(ctx: Ctx, expr: T.IfExpression): string {
    `
 }
 
+function makeLambdaExpression(ctx: Ctx, lambda: T.LambdaExpression): string {
+   const params = lambda.parameters.map(p => p.value).join(', ')
+   const body = generateExpression({ ...ctx, expect_return: true, fn: null }, lambda.body)
+   return `(function (${params}) { ${body} })`
+}
+
+function makeRecordLiteral(ctx: Ctx, record: T.RecordLiteral): string {
+   const fields = record.fields.map(field => {
+      const key = field.name.value
+      const value = generateExpression({ ...ctx, expect_return: false }, field.value)
+      return `${key}: ${value}`
+   }).join(', ')
+
+   const recordObj = `{ ${fields} }`
+   return ctx.expect_return ? `return ${recordObj};` : recordObj
+}
+
+function makeFieldAccess(ctx: Ctx, access: T.FieldAccess): string {
+   const object = access.object.value
+   const fields = access.fields.map(f => f.value).join('.')
+   const accessExpr = `${object}.${fields}`
+   return ctx.expect_return ? `return ${accessExpr};` : accessExpr
+}
+
 export function generateExpression(ctx: Ctx, expr: T.Expression): string {
    if (expr.type === 'application') {
       return makeFunctionCall(ctx, expr)
@@ -123,6 +148,12 @@ export function generateExpression(ctx: Ctx, expr: T.Expression): string {
       return makeLetExpression(ctx, expr)
    } else if (expr.type === 'if-expression') {
       return makeIfExpression(ctx, expr)
+   } else if (expr.type === 'lambda') {
+      return makeLambdaExpression(ctx, expr)
+   } else if (expr.type === 'record-literal') {
+      return makeRecordLiteral(ctx, expr)
+   } else if (expr.type === 'field-access') {
+      return makeFieldAccess(ctx, expr)
    } else if (expr.type === 'string') {
       return `${ctx.expect_return ? `return ${expr.value};` : expr.value}`
    } else if (expr.type === 'number') {
@@ -135,7 +166,7 @@ export function generateExpression(ctx: Ctx, expr: T.Expression): string {
 function tailCalls(fnName: string, expr: T.Expression): T.Application[] {
    // A function call is in tail position if it's the last expression executed
    // before returning from the function
-   
+
    if (expr.type === 'application' && expr.name.value === fnName) {
       return [expr]
    } else if (expr.type === 'if-expression') {
@@ -147,6 +178,15 @@ function tailCalls(fnName: string, expr: T.Expression): T.Application[] {
    } else if (expr.type === 'let-expression') {
       // In a let expression, only the body can contain tail calls
       return tailCalls(fnName, expr.body)
+   } else if (expr.type === 'lambda') {
+      // Lambda expressions create a new scope, so tail calls inside don't apply to outer function
+      return []
+   } else if (expr.type === 'record-literal') {
+      // Record literals don't contain tail calls in tail position
+      return []
+   } else if (expr.type === 'field-access') {
+      // Field access doesn't contain tail calls
+      return []
    } else {
       // Other expressions (numbers, strings, non-recursive calls) can't contain tail calls
       return []

--- a/src/grammar/grammar.jml.pegjs
+++ b/src/grammar/grammar.jml.pegjs
@@ -76,6 +76,18 @@ Literal "literal"
    / String
 
 /***
+Lambda expression: \x y -> x + y
+***/
+LambdaExpression "lambda expression" =
+   "\\" parameters:FunctionParameters Ws? "->" Ws? body:Expression {
+      return withLoc({
+         type: 'lambda',
+         parameters: parameters,
+         body: body,
+      })
+   }
+
+/***
 let
    foo { print "a" }
 in {
@@ -91,6 +103,28 @@ LetExpression "let expression" =
          type: 'let-expression',
          bindings: fns,
          body: body,
+      })
+   }
+
+/***
+Record literal: { foo = 1, bar = 2 }
+***/
+RecordField =
+   name:Identifier Ws? "=" Ws? value:Expression {
+      return withLoc({ name: name, value: value })
+   }
+
+RecordFieldList =
+   head:RecordField
+   tail:(WsNL? "," WsNL? field:RecordField { return field })* {
+      return [head].concat(tail)
+   }
+
+RecordLiteral "record literal" =
+   "{" WsNL? fields:RecordFieldList? WsNL? "}" {
+      return withLoc({
+         type: 'record-literal',
+         fields: fields || [],
       })
    }
 
@@ -115,8 +149,11 @@ IfExpression "if expression" =
 Operand "operand"
    = ParenthesizedExpression
    / LetExpression
+   / LambdaExpression
    / IfExpression
+   / RecordLiteral
    / Literal
+   / FieldAccess
    / Application
 
 InfixOperator "infix op"
@@ -127,6 +164,18 @@ InfixOperator "infix op"
 CallOrOperand
    = Application
    / Operand
+
+/***
+Field access: record.field or record.field1.field2
+***/
+FieldAccess "field access" =
+   object:Identifier fields:("." field:Identifier { return field })+ {
+      return withLoc({
+         type: 'field-access',
+         object: object,
+         fields: fields,
+      })
+   }
 
 Application
    = name:Identifier operands:(Ws e:Operand { return e; })* {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,22 @@ export type IfExpression = {
    true_expression: Expression
    false_expression: Expression
 } & Locatable
-export type Expression = Application | LetExpression | IfExpression | Literal
+export type LambdaExpression = {
+   type: 'lambda'
+   parameters: Identifier[]
+   body: Expression
+} & Locatable
+export type RecordField = { name: Identifier; value: Expression } & Locatable
+export type RecordLiteral = {
+   type: 'record-literal'
+   fields: RecordField[]
+} & Locatable
+export type FieldAccess = {
+   type: 'field-access'
+   object: Identifier
+   fields: Identifier[]
+} & Locatable
+export type Expression = Application | LetExpression | IfExpression | LambdaExpression | RecordLiteral | FieldAccess | Literal
 export type Identifier = {
    type: 'lower-identifier' | 'upper-identifier'
    value: string


### PR DESCRIPTION
Features added:
- Lambda expressions with backslash syntax (\x -> x + 1)
- Record literals with curly braces ({ name = "Alice", age = 30 })
- Field access with dot notation (person.name)

Implementation:
- Updated grammar to support lambda and record syntax
- Added new AST node types for LambdaExpression, RecordLiteral, and FieldAccess
- Implemented JavaScript code generation for all new features
- Fixed null handling in makeFunctionCall for lambda contexts
- Updated tailCalls function to handle new expression types

Examples:
- lambda_example.jml: Demonstrates lambda functions with higher-order functions
- record_example.jml: Shows record creation and field access

All existing tests pass with no regressions.